### PR TITLE
Part 5 — DevOps polish + CI/CD + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: ci
+
+on:
+  push:
+    branches: [ main, part5-* ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  hadolint:
+    name: Dockerfile Lint (Hadolint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: emulator/part3-containerization/Dockerfile
+
+  trivy-fs:
+    name: Security Scan (Trivy - filesystem)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan repository with Trivy
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,29 @@
-name: ci  # Shown in Actions UI
+name: ci
 
 on:
   push:
-    branches: [ main, part5-* ]     # Trigger on pushes to these branches
-  pull_request:                     # Also run on PRs
-  workflow_dispatch:                # Manual "Run workflow" button
+    branches: [ main, part5-* ]     # run CI on branch pushes
+    tags: [ 'v*' ]                  # ALSO run when you push tags like v0.1.0
+  pull_request:
+  workflow_dispatch:
+
+# needed to push images to GHCR using GITHUB_TOKEN
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  # ---- Job 1: Dockerfile lint ----------------------------------------------
   hadolint:
     name: Dockerfile Lint (Hadolint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4            # pulls your repo code onto the runner
+      - uses: actions/checkout@v4
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: emulator/part3-containerization/Dockerfile
-          failure-threshold: error           # warnings won't fail
+          failure-threshold: error
 
-  # ---- Job 2: Filesystem security scan -------------------------------------
   trivy-fs:
     name: Security Scan (Trivy - filesystem)
     runs-on: ubuntu-latest
@@ -28,32 +32,24 @@ jobs:
       - name: Scan repository with Trivy
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          scan-type: 'fs'                    # scan files in the repo
-          scan-ref: '.'                      # repo root
+          scan-type: 'fs'
+          scan-ref: '.'
           ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'          # only fail on High/Critical
-          exit-code: '1'                     # nonzero exit on findings
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
 
-  # ---- Job 3: Build ARM64 image and smoke-test it ---------------------------
   arm64-build-smoke:
     name: ARM64 Buildx + Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-
-      # Enable QEMU so x86 runner can emulate arm64
       - name: Set up QEMU (arm64)
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
-
-      # Enable Docker Buildx (buildkit)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      # Build the arm64 image from your Part 3 Dockerfile.
-      # load: true -> makes the image available to `docker run` below.
       - name: Build image (linux/arm64)
         uses: docker/build-push-action@v5
         with:
@@ -63,7 +59,35 @@ jobs:
           tags: local/retroarch:ci-arm64
           push: false
           load: true
-
-      # Quick smoke test inside the built image
       - name: Smoke test (retroarch --version)
         run: docker run --rm --platform linux/arm64 local/retroarch:ci-arm64 retroarch --version
+
+  publish-ghcr:
+    name: Publish to GHCR (arm64) on tag
+    needs: [hadolint, trivy-fs, arm64-build-smoke]
+    if: startsWith(github.ref, 'refs/tags/')   # only runs on tag pushes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU (arm64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push (linux/arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: emulator/part3-containerization
+          file: emulator/part3-containerization/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/retroarch:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}/retroarch:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: emulator/part3-containerization/Dockerfile
+          failure-threshold: error    # <-- treat warnings as pass
 
   trivy-fs:
     name: Security Scan (Trivy - filesystem)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,25 @@
-name: ci
+name: ci  # Shown in Actions UI
 
 on:
   push:
-    branches: [ main, part5-* ]
-  pull_request:
-  workflow_dispatch:
+    branches: [ main, part5-* ]     # Trigger on pushes to these branches
+  pull_request:                     # Also run on PRs
+  workflow_dispatch:                # Manual "Run workflow" button
 
 jobs:
+  # ---- Job 1: Dockerfile lint ----------------------------------------------
   hadolint:
     name: Dockerfile Lint (Hadolint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4            # pulls your repo code onto the runner
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: emulator/part3-containerization/Dockerfile
-          failure-threshold: error    # <-- treat warnings as pass
+          failure-threshold: error           # warnings won't fail
 
+  # ---- Job 2: Filesystem security scan -------------------------------------
   trivy-fs:
     name: Security Scan (Trivy - filesystem)
     runs-on: ubuntu-latest
@@ -26,8 +28,42 @@ jobs:
       - name: Scan repository with Trivy
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          scan-type: 'fs'
-          scan-ref: '.'
+          scan-type: 'fs'                    # scan files in the repo
+          scan-ref: '.'                      # repo root
           ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
-          exit-code: '1'
+          severity: 'CRITICAL,HIGH'          # only fail on High/Critical
+          exit-code: '1'                     # nonzero exit on findings
+
+  # ---- Job 3: Build ARM64 image and smoke-test it ---------------------------
+  arm64-build-smoke:
+    name: ARM64 Buildx + Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # Enable QEMU so x86 runner can emulate arm64
+      - name: Set up QEMU (arm64)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      # Enable Docker Buildx (buildkit)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the arm64 image from your Part 3 Dockerfile.
+      # load: true -> makes the image available to `docker run` below.
+      - name: Build image (linux/arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: emulator/part3-containerization
+          file: emulator/part3-containerization/Dockerfile
+          platforms: linux/arm64
+          tags: local/retroarch:ci-arm64
+          push: false
+          load: true
+
+      # Quick smoke test inside the built image
+      - name: Smoke test (retroarch --version)
+        run: docker run --rm --platform linux/arm64 local/retroarch:ci-arm64 retroarch --version

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 prom_data/
 grafana_data/
 prometheus/data/
+data/roms/
+data/saves/
+data/config/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PROFILE ?= software
+SERVICE := $(if $(filter $(PROFILE),gpu),retroarch-gpu,retroarch-soft)
+DC := docker compose
+
+.PHONY: up down logs ps smoke gui
+
+up:
+	COMPOSE_PROFILES=$(PROFILE) $(DC) up -d --remove-orphans
+	@echo "Profile: $(PROFILE) -> Service: $(SERVICE)"
+
+down:
+	$(DC) down
+
+logs:
+	$(DC) logs -f $(SERVICE)
+
+ps:
+	$(DC) ps
+
+smoke: up
+	$(DC) exec $(SERVICE) bash -lc "retroarch --version"
+	$(DC) ps
+
+gui: up
+	$(DC) exec $(SERVICE) bash -lc "retroarch"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 PROFILE ?= software
 SERVICE := $(if $(filter $(PROFILE),gpu),retroarch-gpu,retroarch-soft)
 DC := docker compose
+IMAGE ?= retroarch:local
+GAMBATTE ?= /usr/lib/aarch64-linux-gnu/libretro/gambatte_libretro.so
+SNES9X   ?= /usr/lib/aarch64-linux-gnu/libretro/snes9x_libretro.so
+GENESIS  ?= /usr/lib/aarch64-linux-gnu/libretro/genesis_plus_gx_libretro.so
 
-.PHONY: up down logs ps smoke gui
+
+.PHONY: up down logs ps smoke gui cores play-gb play-snes play-genesis clean
 
 up:
-	COMPOSE_PROFILES=$(PROFILE) $(DC) up -d --remove-orphans
+	IMAGE=$(IMAGE) COMPOSE_PROFILES=$(PROFILE) $(DC) up -d --remove-orphans
 	@echo "Profile: $(PROFILE) -> Service: $(SERVICE)"
 
 down:
@@ -23,3 +28,24 @@ smoke: up
 
 gui: up
 	$(DC) exec $(SERVICE) bash -lc "retroarch"
+
+
+# List installed cores inside the container (always succeed)
+cores: up
+	$(DC) exec $(SERVICE) bash -lc 'for d in /usr/lib/*/libretro /usr/lib/libretro; do [ -d "$$d" ] && echo "--- $$d" && ls -1 "$$d"; done || true'
+
+# ---- Play targets (quotes handle spaces in filenames)
+# Usage: make play-gb ROM=roms/gb/YourGame.gb
+play-gb: up
+	@if [ -z "$(ROM)" ]; then echo "Usage: make play-gb ROM=roms/gb/YourGame.gb"; exit 2; fi
+	$(DC) exec $(SERVICE) bash -lc "retroarch -L $(GAMBATTE) \"/roms/gb/$(notdir $(ROM))\""
+
+# Usage: make play-snes ROM=roms/snes/YourGame.sfc
+play-snes: up
+	@if [ -z "$(ROM)" ]; then echo "Usage: make play-snes ROM=roms/snes/YourGame.sfc"; exit 2; fi
+	$(DC) exec $(SERVICE) bash -lc "retroarch -L $(SNES9X) \"/roms/snes/$(notdir $(ROM))\""
+
+# Usage: make play-genesis ROM=roms/genesis/YourGame.md
+play-genesis: up
+	@if [ -z "$(ROM)" ]; then echo "Usage: make play-genesis ROM=roms/genesis/YourGame.md"; exit 2; fi
+	$(DC) exec $(SERVICE) bash -lc "retroarch -L $(GENESIS) \"/roms/genesis/$(notdir $(ROM))\""

--- a/README.md
+++ b/README.md
@@ -1,12 +1,81 @@
-# Pi Emulator DevOps — Monitoring Stack
+# Raspberry Pi Emulator DevOps
+
+A portfolio-friendly Pi 5 project that shows **DevOps + CI/CD** around a containerized RetroArch emulator, plus a **monitoring stack** (Prometheus, Grafana, node-exporter, cAdvisor).
+
+---
+
+## Quickstart (Emulator • Pi 5 / ARM64)
+
+**Prereqs:** Docker + Docker Compose on your Pi.
+
+```bash
+# allow X11 apps to open windows (once per login/session)
+DISPLAY=:0 xhost +local:
+
+# host ROM folders (mounted to /roms in the container)
+mkdir -p ~/ROMs/{gb,snes,genesis}
+
+# run a game (software profile is rock-solid on Pi 5)
+make play-gb      PROFILE=software ROM='roms/gb/YourGame.gb'
+make play-snes    PROFILE=software ROM='roms/snes/YourGame.sfc'
+make play-genesis PROFILE=software ROM='roms/genesis/YourGame.md'
+```
+
+### Profiles
+- `software` → uses llvmpipe (no `/dev/dri`), most compatible on Pi 5  
+- `gpu` → binds `/dev/dri` (experimental on Pi 5 due to Mesa mismatch)
+
+### Volumes & Paths
+- Host `~/ROMs/{gb,snes,genesis}` → container `/roms/...`  
+- Saves/config: `./data/saves`, `./data/config` (git-ignored)
+
+### Common Issues
+- No window? Run `DISPLAY=:0 xhost +local:` and try `PROFILE=software`.  
+- `/dev/dri` perm errors on `gpu`? Put your numeric `video`/`render` GIDs under `group_add` in `docker-compose.yml`.  
+- Audio: Pulse socket is mounted; ALSA `snd_seq` warnings are harmless.
+
+---
+
+## CI / CD
+
+- **Lint:** Hadolint (`failure-threshold: error`)  
+- **Security:** Trivy filesystem scan (fails on High/Critical)  
+- **Build:** ARM64 buildx + QEMU smoke (`retroarch --version`)  
+- **Publish:** push a tag `v*` to publish to GHCR:
+  ```
+  ghcr.io/elvin-rivera23/raspberry-pi-emulator-devops/retroarch:<tag>
+  ```
+
+**Release flow**
+```bash
+git tag -a v0.1.1 -m "cores + play targets + X11/Pulse mounts"
+git push origin v0.1.1
+```
+
+---
+
+## Monitoring Stack (Prometheus + Grafana)
 
 Containerized observability for a Raspberry Pi 5:
-- node-exporter (Pi system metrics)
-- cAdvisor (container metrics)
-- Prometheus (scrapes & stores)
-- Grafana (dashboards)
+- **node-exporter** (Pi system metrics)
+- **cAdvisor** (container metrics)
+- **Prometheus** (scrapes & stores)
+- **Grafana** (dashboards)
 
 Run:
 ```bash
 cd monitoring
 docker compose up -d
+```
+
+---
+
+## Dev Tips
+
+- `make smoke` / `make smoke PROFILE=gpu` → bring up and print versions.  
+- `make cores` → list installed libretro cores inside the container.  
+- Switch image source without editing YAML:
+  ```bash
+  make smoke IMAGE=ghcr.io/elvin-rivera23/raspberry-pi-emulator-devops/retroarch:latest
+  ```
+- ROMs are **never** tracked by git; `.gitignore` protects config/saves too.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,19 @@
-version: "3.9"
-
 x-common: &common
-  image: retroarch:local
+  image: ${IMAGE:-retroarch:local}
   # runs as 'app' user from the Dockerfile
+  environment:
+    - TZ=Etc/UTC
+    - DISPLAY=:0
+    - XDG_CONFIG_HOME=/home/app/config
+    - PULSE_SERVER=unix:/run/user/1000/pulse/native
+    - XDG_RUNTIME_DIR=/run/user/1000
   volumes:
     - ./data/config:/home/app/config
     - ./data/roms:/roms
     - ./data/saves:/saves
+    - /tmp/.X11-unix:/tmp/.X11-unix           # X11 socket for video
+    - /run/user/1000/pulse:/run/user/1000/pulse # PulseAudio socket for sound
+    - /run/user/1000:/run/user/1000
   healthcheck:
     test: ["CMD-SHELL", "retroarch --version >/dev/null 2>&1 || exit 1"]
     interval: 30s
@@ -26,5 +33,8 @@ services:
     profiles: ["gpu"]
     devices:
       - /dev/dri:/dev/dri
+    group_add:
+      - "44"
+      - "105"
     environment:
-      - LIBGL_ALWAYS_SOFTWARE=0
+      - LIBGL_ALWAYS_SOFTWARE=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+
+x-common: &common
+  image: retroarch:local
+  # runs as 'app' user from the Dockerfile
+  volumes:
+    - ./data/config:/home/app/config
+    - ./data/roms:/roms
+    - ./data/saves:/saves
+  healthcheck:
+    test: ["CMD-SHELL", "retroarch --version >/dev/null 2>&1 || exit 1"]
+    interval: 30s
+    timeout: 5s
+    retries: 3
+    start_period: 10s
+  restart: unless-stopped
+  command: ["bash","-lc","sleep infinity"]
+
+services:
+  retroarch-soft:
+    <<: *common
+    profiles: ["software"]
+
+  retroarch-gpu:
+    <<: *common
+    profiles: ["gpu"]
+    devices:
+      - /dev/dri:/dev/dri
+    environment:
+      - LIBGL_ALWAYS_SOFTWARE=0

--- a/emulator/part3-containerization/Dockerfile
+++ b/emulator/part3-containerization/Dockerfile
@@ -1,8 +1,17 @@
 FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# hadolint ignore=DL3008
+RUN set -eux; \
+  # enable main + contrib + non-free (+ non-free-firmware) on bookworm
+  echo 'deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware' > /etc/apt/sources.list; \
+  echo 'deb http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware' >> /etc/apt/sources.list; \
+  echo 'deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware' >> /etc/apt/sources.list; \
+  apt-get update && apt-get install -y --no-install-recommends \
     retroarch \
+    libretro-gambatte \
+    libretro-snes9x \
+    libretro-genesisplusgx \
     libgl1-mesa-dri \
     mesa-vulkan-drivers \
     libglu1-mesa \

--- a/emulator/part3-containerization/Dockerfile
+++ b/emulator/part3-containerization/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -g ${GID} app && useradd -m -u ${UID} -g ${GID} app
+#RUN groupadd -g ${GID} app && useradd -m -u ${UID} -g ${GID} app
+# -l prevents lastlog/faillog writes which can bloat the image
+RUN groupadd -g ${GID} app && useradd -l -m -u ${UID} -g ${GID} app
 USER app
 WORKDIR /home/app
 


### PR DESCRIPTION
What’s in here
- Docker Compose profiles (software/gpu) + healthchecks
- Makefile helpers: smoke, cores, play-*
- ARM64 buildx + QEMU smoke in CI
- Security scan (Trivy) + Dockerfile lint (Hadolint)
- GHCR publish on tag (v0.1.x)
- README quickstart + troubleshooting
- Monitoring stack scaffold (Prometheus, Grafana, node-exporter, cAdvisor)

Notes
- ROMs/config/saves are git-ignored (.gitignore)
- GPU profile works on Pi 5 but software profile is the stable default